### PR TITLE
refactored/improved main scene

### DIFF
--- a/src/main/main.gd
+++ b/src/main/main.gd
@@ -7,12 +7,12 @@ export(PackedScene) var _initial_scene: PackedScene
 
 ### Private variables ###
 var _loader: ResourceInteractiveLoader
-const _poll_time : float = 0.02
+const _poll_time: float = 0.02
 
 ### Onready variables ###
 onready var _anim_player: AnimationPlayer = get_node("AnimationPlayer")
 onready var _fade_rect: ColorRect = get_node("CanvasLayer/ColorRect")
-onready var _loader_poll_timer : Timer = get_node("LoaderPollTimer")
+onready var _loader_poll_timer: Timer = get_node("LoaderPollTimer")
 
 
 ############################
@@ -32,11 +32,13 @@ func _ready() -> void:
 func _on_change_scene_request(scene_res_path: String) -> void:
 	call_deferred("_change_scene_background", scene_res_path)
 
-func _on_animation_finished(anim_name: String) -> void:
+
+func _on_animation_finished(_anim_name: String) -> void:
 	_fade_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
+
 func _on_loader_poll_timer_timeout() -> void:
-	var err = _loader.poll()
+	var err: int = _loader.poll()
 
 	if err == ERR_FILE_EOF: # Finished loading.
 		var resource = _loader.get_resource()
@@ -53,7 +55,7 @@ func _on_loader_poll_timer_timeout() -> void:
 ############################
 #      Private Methods     #
 ############################
-func _fade(is_in : bool) -> void:
+func _fade(is_in: bool) -> void:
 	#BUG: we can do _anim_player.play("fade",-1,1.0,!is_in),
 	#     but apparently calling AnimationPlayer.play() with backward set to true doesn't play backward for some reason
 	
@@ -72,7 +74,6 @@ func _set_current_scene(new_scene: Node) -> void:
 			new_scene, "change_scene_request",
 			self, "_on_change_scene_request"
 	)
-	get_tree().current_scene = new_scene
 	if _anim_player.is_playing():
 		yield(_anim_player, "animation_finished")
 	_fade(false)
@@ -82,14 +83,13 @@ func _change_scene_background(new_scene_path: String) -> void:
 	if new_scene_path == "":
 		new_scene_path = _initial_scene.get_path()
 	
-	
 	_loader = ResourceLoader.load_interactive(new_scene_path, "PackedScene")
 	assert(_loader, "ResourceLoader is null. Attemped load target path: %s" % new_scene_path)
 	
 	_fade(true)
 	yield(_anim_player, "animation_finished")
 	
-	var curr_scene := get_tree().current_scene
+	var curr_scene: Node = get_tree().current_scene
 	if curr_scene:
 		curr_scene.disconnect("change_scene_request", self, "_on_change_scene_request")
 		curr_scene.queue_free()

--- a/src/main/main.gd
+++ b/src/main/main.gd
@@ -6,54 +6,24 @@ extends Node
 export(PackedScene) var _initial_scene: PackedScene
 
 ### Private variables ###
-var _current_scene: Node = null
 var _loader: ResourceInteractiveLoader
-var _pre_load_wait_frame_count: int
-
+const _poll_time : float = 0.02
 
 ### Onready variables ###
 onready var _anim_player: AnimationPlayer = get_node("AnimationPlayer")
 onready var _fade_rect: ColorRect = get_node("CanvasLayer/ColorRect")
+onready var _loader_poll_timer : Timer = get_node("LoaderPollTimer")
 
 
 ############################
 # Engine Callback Methods  #
 ############################
 func _ready() -> void:
-	_set_current_scene(_initial_scene.instance())
-
-
-func _process(_delta: float) -> void:
-	var time_max := 100
-
-	if _loader == null:
-		# No need to process anymore
-		set_process(false)
-		return
-
-	# Wait for n frames to let the "loading" animation show up.
-	if _pre_load_wait_frame_count > 0:
-		_pre_load_wait_frame_count -= 1
-		return
-
-	var t = OS.get_ticks_msec()
-	# Use "time_max" to control for how long this thread is blocked.
-	while OS.get_ticks_msec() < t + time_max:
-		var err = _loader.poll()
+	_loader_poll_timer.wait_time = _poll_time
 	
-		if err == ERR_FILE_EOF: # Finished loading.
-			var resource = _loader.get_resource()
-			_loader = null
-			_set_current_scene(resource.instance())
-			break
-		elif err == OK:
-#			print(float(_loader.get_stage()) / float(_loader.get_stage_count()))
-			# Would update a loading bar here
-			pass
-		else:
-			print("ResourceInteractiveLoader Error: " + str(_loader.poll()))
-			_loader = null
-			break
+	#make sure root is ready to take new child
+	yield(get_tree().root,"ready")
+	_set_current_scene(_initial_scene.instance())
 
 
 ############################
@@ -62,50 +32,67 @@ func _process(_delta: float) -> void:
 func _on_change_scene_request(scene_res_path: String) -> void:
 	call_deferred("_change_scene_background", scene_res_path)
 
+func _on_animation_finished(anim_name: String) -> void:
+	_fade_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+func _on_loader_poll_timer_timeout() -> void:
+	var err = _loader.poll()
+
+	if err == ERR_FILE_EOF: # Finished loading.
+		var resource = _loader.get_resource()
+		_loader = null
+		_set_current_scene(resource.instance())
+	elif err == OK:
+		#print(float(_loader.get_stage()) / float(_loader.get_stage_count()))
+		# Would update a loading bar here
+		_loader_poll_timer.start()
+	else:
+		assert(false,"ResourceInteractiveLoader Error: " + str(_loader.poll()))
+
 
 ############################
 #      Private Methods     #
 ############################
-
-func _fade_out() -> void:
-	_anim_player.play_backwards("fade")
-	yield(_anim_player, "animation_finished")
-
-
-func _fade_in() -> void:
-	_anim_player.play("fade")
-	yield(_anim_player, "animation_finished")
+func _fade(is_in : bool) -> void:
+	#BUG: we can do _anim_player.play("fade",-1,1.0,!is_in),
+	#     but apparently calling AnimationPlayer.play() with backward set to true doesn't play backward for some reason
+	
+	_fade_rect.mouse_filter = Control.MOUSE_FILTER_STOP
+	if is_in:
+		_anim_player.play("fade")
+	else:
+		_anim_player.play_backwards("fade")
 
 
 func _set_current_scene(new_scene: Node) -> void:
-	add_child(new_scene)
+	get_tree().get_root().add_child(new_scene)
+	get_tree().current_scene = new_scene
+	
 	GenUtils.connect_signal_assert_ok(
 			new_scene, "change_scene_request",
 			self, "_on_change_scene_request"
 	)
-	_current_scene = new_scene
+	get_tree().current_scene = new_scene
 	if _anim_player.is_playing():
 		yield(_anim_player, "animation_finished")
-	_fade_out()
+	_fade(false)
 
 
 func _change_scene_background(new_scene_path: String) -> void:
 	if new_scene_path == "":
 		new_scene_path = _initial_scene.get_path()
 	
-	if _current_scene:
-		_current_scene.disconnect("change_scene_request", self, "_on_change_scene_request")
 	
-	_fade_in()
-	_loader = ResourceLoader.load_interactive(new_scene_path)
+	_loader = ResourceLoader.load_interactive(new_scene_path, "PackedScene")
 	assert(_loader, "ResourceLoader is null. Attemped load target path: %s" % new_scene_path)
 	
-	if _anim_player.is_playing():
-		yield(_anim_player, "animation_finished")
+	_fade(true)
+	yield(_anim_player, "animation_finished")
 	
-	if _current_scene:
-		_current_scene.queue_free()
+	var curr_scene := get_tree().current_scene
+	if curr_scene:
+		curr_scene.disconnect("change_scene_request", self, "_on_change_scene_request")
+		curr_scene.queue_free()
+		get_tree().current_scene = null
 	
-	_pre_load_wait_frame_count = 1
-	
-	set_process(true)
+	_loader_poll_timer.start()

--- a/src/main/main.tscn
+++ b/src/main/main.tscn
@@ -49,3 +49,9 @@ color = Color( 1, 1, 1, 0 )
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 anims/RESET = SubResource( 1 )
 anims/fade = SubResource( 2 )
+
+[node name="LoaderPollTimer" type="Timer" parent="."]
+one_shot = true
+
+[connection signal="animation_finished" from="AnimationPlayer" to="." method="_on_animation_finished"]
+[connection signal="timeout" from="LoaderPollTimer" to="." method="_on_loader_poll_timer_timeout"]


### PR DESCRIPTION
I did some refactoring that I think makes more sense, of course feel free to reject any change you don't like I'm just trying to help :)

-removed _current_scene variable in favor of `get_tree().current_scene`, this is more of a standard way of doing it according to the docs, as it doesn't break functions like `get_tree().change_scene()` and `get_tree().reload_current_scene`
-remove frame dependent interactive loading, frame dependency is very much always a bad idea, I added a timer instead. not sure why you want to wait for some time before calling _loader.poll(), but I kept your idea anyway
-made it so that fade rect blocks the mouse while the fade animation is playing, this prevents user from clicking stuff while screen is fading
-some other refactoring and removing of unnecessary code