### PR TITLE
Refactored audio preferences

### DIFF
--- a/src/autoloads/user_preferences.gd
+++ b/src/autoloads/user_preferences.gd
@@ -1,6 +1,17 @@
 extends Node
 # Autoloaded script to contain user preferences
 
+
+### Enums ###
+enum AudioBuses {
+	Master = 0,
+	Sfx = 1,
+	Music = 2,
+	Ui = 3,
+}
+
+
+### Public variables ###
 var audio_vol: Dictionary = {
 	AudioBuses.Master: 0.5,
 	AudioBuses.Sfx: 0.5,
@@ -18,20 +29,22 @@ var vsync: bool = true setget set_vsync
 var fxaa: bool = false setget set_fxaa
 var msaa: int = Viewport.MSAA_4X setget set_msaa
 
-enum AudioBuses {
-	Master = 0,
-	Sfx = 1,
-	Music = 2,
-	Ui = 3,
-	}
+
+############################
+# Engine Callback Methods  #
+############################
 
 func _ready() -> void:
 	_load()
 
 
+############################
+#      Public Methods      #
+############################
+
 func set_audio_vol(bus: int, val: float) -> void:
 	audio_vol[bus] = clamp(val, 0, 1.0)
-	AudioServer.set_bus_volume_db(bus,val)
+	AudioServer.set_bus_volume_db(bus, _vol_linear_to_db(val))
 	AudioServer.set_bus_mute(bus, val == 0) #mute if val is 0, unmute otherwise
 
 
@@ -96,6 +109,7 @@ func save() -> void:
 ############################
 #      Private Methods     #
 ############################
+
 func _vol_db_to_linear(val: float) -> float:
 	return db2linear(val - 6)
 

--- a/src/autoloads/user_preferences.gd
+++ b/src/autoloads/user_preferences.gd
@@ -1,10 +1,12 @@
 extends Node
 # Autoloaded script to contain user preferences
 
-var audio_vol_master: float = 0.5 setget set_audio_vol_master
-var audio_vol_music: float = 0.5 setget set_audio_vol_music
-var audio_vol_sfx: float = 0.5 setget set_audio_vol_sfx
-var audio_vol_ui: float = 0.5 setget set_audio_vol_ui
+var audio_vol: Dictionary = {
+	AudioBuses.Master: 0.5,
+	AudioBuses.Sfx: 0.5,
+	AudioBuses.Music: 0.5,
+	AudioBuses.Ui: 0.5,
+}
 
 var mouse_sensitivity: float = 0.5 setget set_mouse_sensitivity
 var toggle_sprint: bool = true
@@ -16,45 +18,21 @@ var vsync: bool = true setget set_vsync
 var fxaa: bool = false setget set_fxaa
 var msaa: int = Viewport.MSAA_4X setget set_msaa
 
+enum AudioBuses {
+	Master = 0,
+	Sfx = 1,
+	Music = 2,
+	Ui = 3,
+	}
 
 func _ready() -> void:
 	_load()
 
 
-func set_audio_vol_master(val: float) -> void:
-	audio_vol_master = clamp(val, 0, 1.0)
-	if audio_vol_master == 0:
-		AudioServer.set_bus_mute(0, true)
-	else:
-		AudioServer.set_bus_mute(0, false)
-		AudioServer.set_bus_volume_db(0, _vol_linear_to_db(audio_vol_master))
-
-
-func set_audio_vol_music(val: float) -> void:
-	audio_vol_music = clamp(val, 0, 1.0)
-	if audio_vol_music == 0:
-		AudioServer.set_bus_mute(2, true)
-	else:
-		AudioServer.set_bus_mute(2, false)
-		AudioServer.set_bus_volume_db(2, _vol_linear_to_db(audio_vol_music))
-
-
-func set_audio_vol_sfx(val: float) -> void:
-	audio_vol_sfx = clamp(val, 0, 1.0)
-	if audio_vol_sfx == 0:
-		AudioServer.set_bus_mute(1, true)
-	else:
-		AudioServer.set_bus_mute(1, false)
-		AudioServer.set_bus_volume_db(1, _vol_linear_to_db(audio_vol_sfx))
-
-
-func set_audio_vol_ui(val: float) -> void:
-	audio_vol_ui = clamp(val, 0, 1.0)
-	if audio_vol_ui == 0:
-		AudioServer.set_bus_mute(3, true)
-	else:
-		AudioServer.set_bus_mute(3, false)
-		AudioServer.set_bus_volume_db(3, _vol_linear_to_db(audio_vol_ui))
+func set_audio_vol(bus: int, val: float) -> void:
+	audio_vol[bus] = clamp(val, 0, 1.0)
+	AudioServer.set_bus_volume_db(bus,val)
+	AudioServer.set_bus_mute(bus, val == 0) #mute if val is 0, unmute otherwise
 
 
 func set_mouse_sensitivity(val: float) -> void:
@@ -97,10 +75,10 @@ func save() -> void:
 	var prefs_cfg: ConfigFile = ConfigFile.new()
 	var err: int = prefs_cfg.load("user://user_prefs.cfg")
 	if err == OK:
-		prefs_cfg.set_value("user_prefs", "audio_vol_master", audio_vol_master)
-		prefs_cfg.set_value("user_prefs", "audio_vol_music", audio_vol_music)
-		prefs_cfg.set_value("user_prefs", "audio_vol_sfx", audio_vol_sfx)
-		prefs_cfg.set_value("user_prefs", "audio_vol_ui", audio_vol_ui)
+		prefs_cfg.set_value("user_prefs", "audio_vol_master", audio_vol[AudioBuses.Master])
+		prefs_cfg.set_value("user_prefs", "audio_vol_music", audio_vol[AudioBuses.Music])
+		prefs_cfg.set_value("user_prefs", "audio_vol_sfx", audio_vol[AudioBuses.Sfx])
+		prefs_cfg.set_value("user_prefs", "audio_vol_ui", audio_vol[AudioBuses.Ui])
 		
 		prefs_cfg.set_value("user_prefs", "mouse_sensitivity", mouse_sensitivity)
 		prefs_cfg.set_value("user_prefs", "toggle_sprint", toggle_sprint)
@@ -133,10 +111,10 @@ func _load() -> void:
 	if err == OK:
 		# Using set funcs for most so preferences are applied when this autoload
 		# enters the sceen tree as the game program starts.
-		set_audio_vol_master(prefs_cfg.get_value("user_prefs", "audio_vol_master"))
-		set_audio_vol_music(prefs_cfg.get_value("user_prefs", "audio_vol_music"))
-		set_audio_vol_sfx(prefs_cfg.get_value("user_prefs", "audio_vol_sfx"))
-		set_audio_vol_ui(prefs_cfg.get_value("user_prefs", "audio_vol_ui"))
+		set_audio_vol(AudioBuses.Master,prefs_cfg.get_value("user_prefs", "audio_vol_master"))
+		set_audio_vol(AudioBuses.Music,prefs_cfg.get_value("user_prefs", "audio_vol_music"))
+		set_audio_vol(AudioBuses.Sfx,prefs_cfg.get_value("user_prefs", "audio_vol_sfx"))
+		set_audio_vol(AudioBuses.Ui,prefs_cfg.get_value("user_prefs", "audio_vol_ui"))
 		
 		set_mouse_sensitivity(prefs_cfg.get_value("user_prefs", "mouse_sensitivity"))
 		toggle_sprint = prefs_cfg.get_value("user_prefs", "toggle_sprint")

--- a/src/ui/settings_page/settings_page.gd
+++ b/src/ui/settings_page/settings_page.gd
@@ -25,10 +25,10 @@ onready var _option_btn_msaa: OptionButton = find_node("MSAAOptionButton")
 # Engine Callback Methods  #
 ############################
 func _ready() -> void:
-	_slider_audio_master.value = UserPreferences.audio_vol_master
-	_slider_audio_sfx.value = UserPreferences.audio_vol_sfx
-	_slider_audio_music.value = UserPreferences.audio_vol_music
-	_slider_audio_ui.value = UserPreferences.audio_vol_ui
+	_slider_audio_master.value = UserPreferences.audio_vol[UserPreferences.AudioBuses.Master]
+	_slider_audio_sfx.value = UserPreferences.audio_vol[UserPreferences.AudioBuses.Sfx]
+	_slider_audio_music.value = UserPreferences.audio_vol[UserPreferences.AudioBuses.Music]
+	_slider_audio_ui.value = UserPreferences.audio_vol[UserPreferences.AudioBuses.Ui]
 	
 	_slider_mouse_sensitivity.value = UserPreferences.mouse_sensitivity
 	_check_btn_toggle_sprint.pressed = UserPreferences.toggle_sprint
@@ -55,24 +55,9 @@ func _on_btn_back_pressed() -> void:
 		_audio_btn_pressed.play()
 
 
-func _on_slider_audio_master_value_changed(value: float) -> void:
+func _on_audio_slider_value_changed(value: float, bus: int) -> void:
 	if active:
-		UserPreferences.audio_vol_master = value
-
-
-func _on_slider_audio_sfx_value_changed(value: float) -> void:
-	if active:
-		UserPreferences.audio_vol_sfx = value
-
-
-func _on_sider_audio_music_value_changed(value: float) -> void:
-	if active:
-		UserPreferences.audio_vol_music = value
-
-
-func _on_sider_audio_ui_value_changed(value: float) -> void:
-	if active:
-		UserPreferences.audio_vol_ui = value
+		UserPreferences.set_audio_vol(bus,value)
 
 
 func _on_slider_mouse_sense_value_changed(value: float) -> void:

--- a/src/ui/settings_page/settings_page.gd
+++ b/src/ui/settings_page/settings_page.gd
@@ -41,7 +41,7 @@ func _ready() -> void:
 	_option_btn_msaa.selected = UserPreferences.msaa
 
 
-func _physics_process(_delta) -> void:
+func _physics_process(_delta: float) -> void:
 	_label_fps.text = String(Performance.get_monitor(Performance.TIME_FPS))
 
 
@@ -57,7 +57,7 @@ func _on_btn_back_pressed() -> void:
 
 func _on_audio_slider_value_changed(value: float, bus: int) -> void:
 	if active:
-		UserPreferences.set_audio_vol(bus,value)
+		UserPreferences.set_audio_vol(bus, value)
 
 
 func _on_slider_mouse_sense_value_changed(value: float) -> void:

--- a/src/ui/settings_page/settings_page.tscn
+++ b/src/ui/settings_page/settings_page.tscn
@@ -406,10 +406,10 @@ __meta__ = {
 }
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/BtnBack" to="." method="_on_btn_back_pressed"]
-[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer/SliderAudioMaster" to="." method="_on_slider_audio_master_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer2/SliderAudioSFX" to="." method="_on_slider_audio_sfx_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer3/SliderAudioMusic" to="." method="_on_sider_audio_music_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer4/SliderAudioUI" to="." method="_on_sider_audio_ui_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer/SliderAudioMaster" to="." method="_on_audio_slider_value_changed" binds= [ 0 ]]
+[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer2/SliderAudioSFX" to="." method="_on_audio_slider_value_changed" binds= [ 1 ]]
+[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer3/SliderAudioMusic" to="." method="_on_audio_slider_value_changed" binds= [ 2 ]]
+[connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Audio/HBoxContainer4/SliderAudioUI" to="." method="_on_audio_slider_value_changed" binds= [ 3 ]]
 [connection signal="value_changed" from="VBoxContainer/PanelContainer/VBoxContainer/Gameplay/HBoxContainer/SliderMouseSense" to="." method="_on_slider_mouse_sense_value_changed"]
 [connection signal="pressed" from="VBoxContainer/PanelContainer/VBoxContainer/Gameplay/ToggleSprintCheckButton" to="." method="_on_check_btn_toggle_sprint_pressed"]
 [connection signal="pressed" from="VBoxContainer/PanelContainer/VBoxContainer/Gameplay/ToggleAimCheckButton" to="." method="_on_check_btn_toggle_aim_pressed"]


### PR DESCRIPTION
-`audio_preferences.gd` now relies on bus indexes stored in a dedicated enum instead of using magic numbers
-refactored repetitive code
-modified/refactored `settings_page.gd` to work with the new change