### PR TITLE
Small improvements to music manager

### DIFF
--- a/src/autoloads/music/music_manager.gd
+++ b/src/autoloads/music/music_manager.gd
@@ -6,7 +6,7 @@ extends Node
 
 ### Enums ###
 enum Tracks {
-	None,
+	NONE,
 	MAIN_MENU,
 	ON_RANGE,
 	OFF_RANGE,
@@ -14,7 +14,7 @@ enum Tracks {
 
 
 ### Private variables ###
-var _current_track_id: int = Tracks.None
+var _current_track_id: int = Tracks.NONE
 
 
 ### Onready variables ###
@@ -35,7 +35,7 @@ func transition_to_track(new_track_id: int, fade_time: float=1.5, transition_del
 			"MusicManager Error: Tried to transition to non-existent track."
 	)
 	
-	if _current_track_id != Tracks.None:
+	if _current_track_id != Tracks.NONE:
 		_track_fade(_current_track_id, false, fade_time)
 		if transition_delay > 0.0:
 			yield(get_tree().create_timer(transition_delay), "timeout")

--- a/src/level_components/level.gd
+++ b/src/level_components/level.gd
@@ -42,7 +42,7 @@ onready var _audio_player_run_end: AudioStreamPlayer = $AudioStreamRunEnd
 ############################
 func _ready() -> void:
 	MusicManager.transition_to_track(
-			MusicManager.Tracks.OFF_RANGE, true, 3
+			MusicManager.Tracks.OFF_RANGE, 3
 	)
 	_player.camera_system = _camera_system
 	
@@ -164,7 +164,7 @@ func _connect_signals() -> void:
 
 func _start_run() -> void:
 	MusicManager.transition_to_track(
-			MusicManager.Tracks.ON_RANGE, true, 1
+			MusicManager.Tracks.ON_RANGE, 1
 	)
 	_audio_player_run_start.play()
 	_is_player_on_range = true
@@ -195,7 +195,7 @@ func _update_and_show_run_summary(missed_enemy_penalty_time_total: float, hit_fr
 
 func _finish_run() -> void:
 	MusicManager.transition_to_track(
-			MusicManager.Tracks.OFF_RANGE, true, 3
+			MusicManager.Tracks.OFF_RANGE, 3
 	)
 	_audio_player_run_end.play()
 	_is_player_on_range = false

--- a/src/ui/main_menu/home/home.gd
+++ b/src/ui/main_menu/home/home.gd
@@ -3,7 +3,7 @@ extends MultiPageUIPage
 
 func _ready() -> void:
 	MusicManager.transition_to_track(
-			MusicManager.Tracks.MAIN_MENU, true, 3
+			MusicManager.Tracks.MAIN_MENU, 3
 	)
 
 


### PR DESCRIPTION
-added Tracks.None enum for invalid track id
-removed cross_fade option since it had no practical use
-cleaned the tween usage in `_track_fade` by using tween chaining (Note that you don't have to reassign a tween to apply change)
also used `TRANS_SINE` instead of `TRANS_EXPO` and changed lowest volum to -20 to make audio fading more seamless, [based on this cheat sheet](https://i.redd.it/zdzhci8octp41.png)

still working on music as of now...